### PR TITLE
Add farm job example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # chat
+
+This repository contains sample resources for ESX-based FiveM servers.
+
+## Included resources
+
+- **esx_job_blips**: Example of job-restricted map blips.
+- **farm_job**: Simple farming job using ox_inventory, ox_lib and ox_target.

--- a/farm_job/client.lua
+++ b/farm_job/client.lua
@@ -1,0 +1,87 @@
+ESX = nil
+
+CreateThread(function()
+    while ESX == nil do
+        TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
+        Wait(0)
+    end
+end)
+
+local function harvest(data)
+    if lib.progressBar({duration = Config.Progress.Harvest, label = data.label}) then
+        TriggerServerEvent('farm_job:harvest', data.item, data.count)
+    end
+end
+
+local function processItem(data)
+    if lib.progressBar({duration = Config.Progress.Process, label = data.label}) then
+        TriggerServerEvent('farm_job:process', data.from, data.to, data.count)
+    end
+end
+
+local function cookItem(data)
+    if lib.progressBar({duration = Config.Progress.Cook, label = data.label}) then
+        TriggerServerEvent('farm_job:cook', data.items, data.result, data.count)
+    end
+end
+
+local function setupTargets()
+    for i, data in pairs(Config.HarvestPoints) do
+        exports.ox_target:addBoxZone({
+            coords = data.coords,
+            size = vec3(2, 2, 2),
+            rotation = 0,
+            debug = false,
+            options = {
+                {
+                    name = 'farm_harvest_' .. i,
+                    icon = 'fa-solid fa-seedling',
+                    label = data.label,
+                    onSelect = function()
+                        harvest(data)
+                    end
+                }
+            }
+        })
+    end
+
+    for i, data in pairs(Config.ProcessPoints) do
+        exports.ox_target:addBoxZone({
+            coords = data.coords,
+            size = vec3(2, 2, 2),
+            rotation = 0,
+            debug = false,
+            options = {
+                {
+                    name = 'farm_process_' .. i,
+                    icon = 'fa-solid fa-snowflake',
+                    label = data.label,
+                    onSelect = function()
+                        processItem(data)
+                    end
+                }
+            }
+        })
+    end
+
+    for i, data in pairs(Config.CookPoints) do
+        exports.ox_target:addBoxZone({
+            coords = data.coords,
+            size = vec3(2, 2, 2),
+            rotation = 0,
+            debug = false,
+            options = {
+                {
+                    name = 'farm_cook_' .. i,
+                    icon = 'fa-solid fa-utensils',
+                    label = data.label,
+                    onSelect = function()
+                        cookItem(data)
+                    end
+                }
+            }
+        })
+    end
+end
+
+CreateThread(setupTargets)

--- a/farm_job/config.lua
+++ b/farm_job/config.lua
@@ -1,0 +1,25 @@
+Config = {}
+
+-- Coordinates for interaction points
+Config.HarvestPoints = {
+    {coords = vec3(2300.0, 4885.0, 41.8), item = 'grain', count = 1, label = 'Harvest Grain'},
+    {coords = vec3(2310.0, 4885.0, 41.8), item = 'chicken', count = 1, label = 'Collect Chicken'},
+    {coords = vec3(2320.0, 4885.0, 41.8), item = 'duck', count = 1, label = 'Collect Duck'}
+}
+
+Config.ProcessPoints = {
+    {coords = vec3(2330.0, 4885.0, 41.8), from = 'chicken', to = 'frozen_chicken', count = 1, label = 'Freeze Chicken'},
+    {coords = vec3(2340.0, 4885.0, 41.8), from = 'duck', to = 'frozen_duck', count = 1, label = 'Freeze Duck'}
+}
+
+Config.CookPoints = {
+    {coords = vec3(2350.0, 4885.0, 41.8), items = { {item = 'frozen_chicken', count = 1}, {item = 'grain', count = 2} }, result = 'roasted_chicken', count = 1, label = 'Cook Roasted Chicken'},
+    {coords = vec3(2360.0, 4885.0, 41.8), items = { {item = 'frozen_duck', count = 1}, {item = 'grain', count = 1} }, result = 'duck_soup', count = 1, label = 'Cook Duck Soup'}
+}
+
+-- Time in milliseconds for progress bars
+Config.Progress = {
+    Harvest = 3000,
+    Process = 4000,
+    Cook = 5000
+}

--- a/farm_job/fxmanifest.lua
+++ b/farm_job/fxmanifest.lua
@@ -1,0 +1,25 @@
+fx_version 'cerulean'
+game 'gta5'
+
+description 'Example farm job using ESX, ox_inventory, ox_lib and ox_target'
+
+shared_scripts {
+    '@ox_lib/init.lua',
+    'config.lua'
+}
+
+client_scripts {
+    'client.lua'
+}
+
+server_scripts {
+    '@mysql-async/lib/MySQL.lua',
+    'server.lua'
+}
+
+dependencies {
+    'es_extended',
+    'ox_inventory',
+    'ox_lib',
+    'ox_target'
+}

--- a/farm_job/server.lua
+++ b/farm_job/server.lua
@@ -1,0 +1,34 @@
+ESX = nil
+TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
+
+local function hasItems(src, items)
+    for _, data in pairs(items) do
+        local count = exports.ox_inventory:Search(src, 'count', data.item)
+        if count < data.count then
+            return false
+        end
+    end
+    return true
+end
+
+RegisterNetEvent('farm_job:harvest', function(item, count)
+    local src = source
+    exports.ox_inventory:AddItem(src, item, count)
+end)
+
+RegisterNetEvent('farm_job:process', function(from, to, count)
+    local src = source
+    if exports.ox_inventory:RemoveItem(src, from, count) then
+        exports.ox_inventory:AddItem(src, to, count)
+    end
+end)
+
+RegisterNetEvent('farm_job:cook', function(items, result, count)
+    local src = source
+    if not hasItems(src, items) then return end
+
+    for _, item in pairs(items) do
+        exports.ox_inventory:RemoveItem(src, item.item, item.count)
+    end
+    exports.ox_inventory:AddItem(src, result, count)
+end)


### PR DESCRIPTION
## Summary
- add sample ox-based farm job resource
- update README with list of resources

## Testing
- `luac -p farm_job/*.lua`

------
https://chatgpt.com/codex/tasks/task_e_68505582e1a0833089f968c9407fdb1e