### PR TITLE
Add basic translation support

### DIFF
--- a/fbitracker/client.lua
+++ b/fbitracker/client.lua
@@ -26,7 +26,7 @@ function startTrackerRemovalMinigame(type, id)
     if success then
         TriggerServerEvent('fbi:completeTrackerRemoval', type, id)
     else
-        lib.notify({title = 'GPS Detector', description = '❌ Nepodařilo se odstranit tracker!', type = 'error'})
+        lib.notify({title = 'GPS Detector', description = _L('❌ Nepodařilo se odstranit tracker!'), type = 'error'})
     end
 end
 
@@ -36,7 +36,7 @@ end
 RegisterCommand('installgps', function()
     local player = ESX.GetPlayerData()
     if player.job.name ~= Config.RequiredJob then
-        lib.notify({title = 'FBI', description = '🚫 Nemáš oprávnění instalovat GPS!', type = 'error'})
+        lib.notify({title = 'FBI', description = _L('🚫 Nemáš oprávnění instalovat GPS!'), type = 'error'})
         return
     end
 
@@ -55,7 +55,7 @@ RegisterCommand('installgps', function()
     end
 
     if #nearbyPlayers == 0 then
-        lib.notify({title = 'FBI', description = '🚫 Nikdo v blízkosti.', type = 'error'})
+        lib.notify({title = 'FBI', description = _L('🚫 Nikdo v blízkosti.'), type = 'error'})
         return
     end
 
@@ -71,7 +71,7 @@ RegisterCommand('installgps', function()
 
     lib.registerContext({
         id = 'fbi_install_gps_menu',
-        title = '📡 Instalace GPS Trackeru',
+        title = _L('📡 Instalace GPS Trackeru'),
         options = options
     })
     lib.showContext('fbi_install_gps_menu')
@@ -83,7 +83,7 @@ CreateThread(function()
         {
             name = 'install_gps_vehicle',
             icon = 'fa-solid fa-location-crosshairs',
-            label = '🚗 Nainstalovat GPS Tracker na vozidlo',
+            label = _L('🚗 Nainstalovat GPS Tracker na vozidlo'),
             canInteract = function(entity)
                 local player = ESX.GetPlayerData()
                 return player.job.name == Config.RequiredJob
@@ -100,16 +100,16 @@ end)
 -- Hlavní tablet
 lib.registerContext({
     id = 'fbi_tablet_main',
-    title = '📂 FBI Tablet',
+    title = _L('📂 FBI Tablet'),
     options = {
         {
-            title = '📂 Sledování osob',
+                title = _L('📂 Sledování osob'),
             onSelect = function()
                 TriggerServerEvent('fbi:getActiveGpsTaps', 'gps_person')
             end
         },
         {
-            title = '🚗 Sledování vozidel',
+                title = _L('🚗 Sledování vozidel'),
             onSelect = function()
                 TriggerServerEvent('fbi:getActiveGpsTaps', 'gps_vehicle')
             end
@@ -128,7 +128,7 @@ CreateThread(function()
             {
                 name = 'open_fbi_tablet',
                 icon = 'fa-solid fa-tablet-screen-button',
-                label = '📂 Otevřít FBI Tablet',
+            label = _L('📂 Otevřít FBI Tablet'),
                 canInteract = function()
                     local player = ESX.GetPlayerData()
                     return player.job.name == Config.RequiredJob
@@ -144,7 +144,7 @@ CreateThread(function()
         {
             name = 'install_gps',
             icon = 'fa-solid fa-location-crosshairs',
-            label = '📡 Nainstalovat GPS Tracker',
+            label = _L('📡 Nainstalovat GPS Tracker'),
             canInteract = function()
                 local player = ESX.GetPlayerData()
                 return player.job.name == Config.RequiredJob
@@ -162,7 +162,7 @@ RegisterCommand('fbitablet', function()
     if player.job.name == Config.RequiredJob then
         lib.showContext('fbi_tablet_main')
     else
-        lib.notify({title = 'FBI', description = '🚫 Nemáš přístup k FBI Tabletu!', type = 'error'})
+        lib.notify({title = 'FBI', description = _L('🚫 Nemáš přístup k FBI Tabletu!'), type = 'error'})
     end
 end)
 
@@ -177,12 +177,12 @@ RegisterNetEvent('fbi:updatePlayerTrackerBlip', function(trackerId, x, y, z, typ
             SetBlipSprite(blip, 225)
             SetBlipColour(blip, 2)
             BeginTextCommandSetBlipName('STRING')
-            AddTextComponentString('🚗 Sledované vozidlo')
+            AddTextComponentString(_L('🚗 Sledované vozidlo'))
         else
             SetBlipSprite(blip, 480)
             SetBlipColour(blip, 1)
             BeginTextCommandSetBlipName('STRING')
-            AddTextComponentString('🎯 Sledovaná osoba')
+            AddTextComponentString(_L('🎯 Sledovaná osoba'))
         end
 
         EndTextCommandSetBlipName(blip)
@@ -240,7 +240,7 @@ RegisterNetEvent('fbi:showTablet', function(taps, tapType)
                             onSelect = function()
                                 TriggerServerEvent('fbi:deleteGpsTracker', tap.id, tap.target_charid)
                                 TriggerEvent('fbi:removePlayerTrackerBlip', tap.target_charid)
-                                lib.notify({title = 'FBI', description = '✅ Tracker odstraněn.', type = 'success'})
+                                lib.notify({title = 'FBI', description = _L('✅ Tracker odstraněn.'), type = 'success'})
                             end
                         }
                     }
@@ -252,7 +252,7 @@ RegisterNetEvent('fbi:showTablet', function(taps, tapType)
 
     lib.registerContext({
         id = 'fbi_tap_tablet_' .. tapType,
-        title = tapType == 'gps_person' and '📂 Sledování osob' or '🚗 Sledování vozidel',
+        title = tapType == 'gps_person' and _L('📂 Sledování osob') or _L('🚗 Sledování vozidel'),
         options = options
     })
     lib.showContext('fbi_tap_tablet_' .. tapType)
@@ -275,7 +275,7 @@ RegisterNetEvent('fbi:scanNearbyVehicle', function()
         local plate = GetVehicleNumberPlateText(nearbyVehicle)
         startTrackerRemovalMinigame('vehicle', plate)
     else
-        lib.notify({title = 'GPS Detector', description = '❌ Žádné vozidlo poblíž.', type = 'error'})
+        lib.notify({title = 'GPS Detector', description = _L('❌ Žádné vozidlo poblíž.'), type = 'error'})
     end
 end)
 
@@ -284,16 +284,16 @@ end)
 exports('useGpsDetector', function(data, slot)
     lib.registerContext({
         id = 'gps_detector_menu',
-        title = '🛰️ Vyber akci s GPS Detektorem',
+        title = _L('🛰️ Vyber akci s GPS Detektorem'),
         options = {
             {
-                title = '🎯 Skenuj hráče',
+                title = _L('🎯 Skenuj hráče'),
                 onSelect = function()
                     TriggerServerEvent('fbi:checkTrackerOnPlayer')
                 end
             },
             {
-                title = '🚗 Skenuj vozidlo',
+                title = _L('🚗 Skenuj vozidlo'),
                 onSelect = function()
                     TriggerEvent('fbi:scanNearbyVehicle')
                 end
@@ -332,10 +332,10 @@ end)
 RegisterNetEvent('fbi:showTrackerFound', function(type)
     lib.registerContext({
         id = 'fbi_tracker_found',
-        title = '🔍 Tracker Detected',
+        title = _L('🔍 Tracker Detected'),
         options = {
             {
-                title = '❌ Pokusit se odstranit tracker',
+                title = _L('❌ Pokusit se odstranit tracker'),
                 onSelect = function()
                     startTrackerRemovalMinigame(type, nil)
                 end

--- a/fbitracker/config.lua
+++ b/fbitracker/config.lua
@@ -1,5 +1,39 @@
 Config = {}
 
+-- Language selection
+Config.Locale = 'en'
+
+-- Basic translations used by the tracker
+Config.Lang = {
+    en = {
+        ['❌ Nepodařilo se odstranit tracker!'] = '❌ Failed to remove tracker!',
+        ['🚫 Nemáš oprávnění instalovat GPS!'] = '🚫 You do not have permission to install GPS!',
+        ['🚫 Nikdo v blízkosti.'] = '🚫 No one nearby.',
+        ['📡 Instalace GPS Trackeru'] = '📡 Install GPS Tracker',
+        ['🚗 Nainstalovat GPS Tracker na vozidlo'] = '🚗 Install GPS Tracker on vehicle',
+        ['📂 FBI Tablet'] = '📂 FBI Tablet',
+        ['📂 Sledování osob'] = '📂 Person Tracking',
+        ['🚗 Sledování vozidel'] = '🚗 Vehicle Tracking',
+        ['📂 Otevřít FBI Tablet'] = '📂 Open FBI Tablet',
+        ['📡 Nainstalovat GPS Tracker'] = '📡 Install GPS Tracker',
+        ['🚗 Vozidlo nebylo nalezeno!'] = '🚗 Vehicle not found!',
+        ['✅ Tracker odstraněn.'] = '✅ Tracker removed.',
+        ['❌ Žádné vozidlo poblíž.'] = '❌ No vehicle nearby.',
+        ['🛰️ Vyber akci s GPS Detektorem'] = '🛰️ Choose action with GPS Detector',
+        ['🎯 Skenuj hráče'] = '🎯 Scan player',
+        ['🚗 Skenuj vozidlo'] = '🚗 Scan vehicle',
+        ['🔍 Tracker Detected'] = '🔍 Tracker Detected',
+        ['❌ Pokusit se odstranit tracker'] = '❌ Try to remove tracker',
+        ['🚫 Nemáš přístup k FBI Tabletu!'] = '🚫 You have no access to the FBI Tablet!'
+    },
+    cz = {}
+}
+
+function _L(key)
+    local lang = Config.Lang[Config.Locale] or {}
+    return lang[key] or key
+end
+
 Config.TapDeviceItem = 'tap_device'
 Config.GpsTrackerItem = 'gps_tracker'
 Config.RequiredJob = 'fbi'
@@ -13,3 +47,4 @@ Config.TabletZone = {
 
 Config.DetectorRadius = 3.0 -- Maximální vzdálenost od vozidla (v metrech)
 Config.DetectorFailureChance = 1 -- % šance na selhání odstranění trackeru
+

--- a/lihovar_job/client/blips.lua
+++ b/lihovar_job/client/blips.lua
@@ -3,10 +3,10 @@ local blips = {}
 
 local function createBlips()
     local locations = {
-        { label = "Sber Obilí", coords = vec3(349.99, 6517.27, 28.6), sprite = 496, color = 25 },
-        { label = "Vyroba lihovar", coords = vec3(2913.0964, 4475.8999, 48.3450), sprite = 566, color = 1 },
-        { label = "Koupe surovin", coords = vec3(-56.9761, 6521.2544, 31.4908), sprite = 566, color = 1 },
-        { label = "Prodej produktu", coords = vec3(3798.9663, 4446.5811, 4.3378), sprite = 566, color = 1 }
+        { label = _L('Sber Obilí'), coords = vec3(349.99, 6517.27, 28.6), sprite = 496, color = 25 },
+        { label = _L('Vyroba lihovar'), coords = vec3(2913.0964, 4475.8999, 48.3450), sprite = 566, color = 1 },
+        { label = _L('Koupe surovin'), coords = vec3(-56.9761, 6521.2544, 31.4908), sprite = 566, color = 1 },
+        { label = _L('Prodej produktu'), coords = vec3(3798.9663, 4446.5811, 4.3378), sprite = 566, color = 1 }
     }
 
     for _, loc in pairs(locations) do

--- a/lihovar_job/client/bottle.lua
+++ b/lihovar_job/client/bottle.lua
@@ -4,15 +4,15 @@ AddEventHandler('lihovar:washinganim', function()
     local count2 = lib.callback.await('lihovar:getItemCount2')
     if count <= 0 then
         lib.notify({
-            title = 'Lihovar',
-            description = 'Nemáš špinavé láhve',
+            title = _L('Lihovar'),
+            description = _L('Nemáš špinavé láhve'),
             type = 'error'
         })
         washing = false
     elseif count2 <= 0 then
         local alert = lib.alertDialog({
-            header = 'Lihovar',
-            content = 'Nemáš houbičku na mytí, chceš umýt láhve pouze rukou?',
+            header = _L('Lihovar'),
+            content = _L('Nemáš houbičku na mytí, chceš umýt láhve pouze rukou?'),
             centered = true,
             cancel = true
         })
@@ -25,7 +25,7 @@ AddEventHandler('lihovar:washinganim', function()
                     washing = true
                     exports.ox_inventory:Progress({
                         duration = 2500,
-                        label = "Umýváš láhve",
+                        label = _L('Umýváš láhve'),
                         useWhileDead = false,
                         canCancel = true,
                         disable = {
@@ -43,15 +43,15 @@ AddEventHandler('lihovar:washinganim', function()
                 end
             else
                 lib.notify({
-                    title = 'Lihovar',
-                    description = 'Nepovedlo se ti umýt flašku v ruce',
+                    title = _L('Lihovar'),
+                    description = _L('Nepovedlo se ti umýt flašku v ruce'),
                     type = 'error'
                 })
             end
         else
             lib.notify({
-                title = 'Lihovar',
-                description = 'Nemáš houbičku na mytí',
+                title = _L('Lihovar'),
+                description = _L('Nemáš houbičku na mytí'),
                 type = 'error'
             })
             washing = false
@@ -61,7 +61,7 @@ AddEventHandler('lihovar:washinganim', function()
             washing = true
             exports.ox_inventory:Progress({
                 duration = 2500,
-                label = "Umýváš láhve",
+                label = _L('Umýváš láhve'),
                 useWhileDead = false,
                 canCancel = true,
                 disable = {
@@ -90,7 +90,7 @@ Citizen.CreateThread(function()
         options = {
             {
                 event = "lihovar:washinganim",
-                label = "Umít láhve"
+                label = _L('Umít láhve')
             }
         },
         job = {"lihovar"},

--- a/lihovar_job/client/buy.lua
+++ b/lihovar_job/client/buy.lua
@@ -15,7 +15,7 @@ local function createShop()
         {
             name = "lihovar_shop_target",
             icon = Config.ShopNPC.icon,
-            label = Config.ShopNPC.targetLabel,
+            label = _L(Config.ShopNPC.targetLabel),
             canInteract = function(entity, distance, coords, name)
                 return ESX.GetPlayerData().job.name == Config.ShopNPC.requiredJob
             end,
@@ -23,13 +23,13 @@ local function createShop()
                 local options = {}
                 for _, item in pairs(Config.ShopNPC.items) do
                     table.insert(options, {
-                        title = (item.label or item.name) .. " ($" .. item.price .. ")",
+                        title = (_L(item.label) or item.name) .. " ($" .. item.price .. ")",
                         icon = 'cart-shopping',
                         onSelect = function()
-                            local input = lib.inputDialog('Nákup: ' .. item.label, {
+                            local input = lib.inputDialog(_L('Nákup: ') .. _L(item.label), {
                                 {
                                     type = 'number',
-                                    label = 'Kolik chceš koupit?',
+                                    label = _L('Kolik chceš koupit?'),
                                     default = 1,
                                     min = 1
                                 }
@@ -44,7 +44,7 @@ local function createShop()
 
                 lib.registerContext({
                     id = 'lihovar_shop_menu',
-                    title = 'lihovar obchod',
+                    title = _L('lihovar obchod'),
                     options = options
                 })
 

--- a/lihovar_job/client/client.lua
+++ b/lihovar_job/client/client.lua
@@ -27,7 +27,7 @@ local icons = {
 }
 
 local labels = {
-    process = "Destilace lihovin"
+    process = _L('Destilace lihovin')
 }
 
 local craftingZoneIds = {}
@@ -54,12 +54,12 @@ local function registerCraftingTargets()
             debug = false,
             options = {{
                 icon = icons[zone.type] or "fa-solid fa-cogs",
-                label = labels[zone.type] or "Výroba",
+                label = labels[zone.type] or _L('Výroba'),
                 onSelect = function()
                     local menuId = 'lihovar_menu_' .. zone.type
                     lib.registerContext({
                         id = menuId,
-                        title = labels[zone.type] or zone.label,
+                        title = labels[zone.type] or _L(zone.label),
                         options = Config.CraftOptions[zone.type] or {}
                     })
                     lib.showContext(menuId)
@@ -83,7 +83,7 @@ RegisterNetEvent('lihovar:playCraftAnim', function(type)
 
     lib.progressBar({
         duration = duration,
-        label = 'Probíhá výroba...',
+        label = _L('Probíhá výroba...'),
         useWhileDead = false,
         canCancel = false,
         disable = {

--- a/lihovar_job/client/harvest.lua
+++ b/lihovar_job/client/harvest.lua
@@ -42,7 +42,7 @@ function SpawnPlants()
         exports.ox_target:addLocalEntity(plant, {
             {
                 icon = "fas fa-seedling",
-                label = "Sesbírat obilí",
+                label = _L('Sesbírat obilí'),
                 canInteract = function(entity, distance, coords, name)
                     return ESX.GetPlayerData().job.name == Config.RequiredJob
                 end,

--- a/lihovar_job/client/sell.lua
+++ b/lihovar_job/client/sell.lua
@@ -15,7 +15,7 @@ local function createBuyer()
         {
             name = "lihovar_buyer_target",
             icon = Config.BuyerNPC.icon,
-            label = Config.BuyerNPC.targetLabel,
+            label = _L(Config.BuyerNPC.targetLabel),
             canInteract = function(entity, distance, coords, name)
                 return ESX.GetPlayerData().job.name == Config.BuyerNPC.requiredJob
             end,
@@ -25,14 +25,14 @@ local function createBuyer()
                     local count = exports.ox_inventory:Search('count', item.name)
                     if count and count > 0 then
                         table.insert(options, {
-                            title = ('%s ($%s / ks)'):format(item.label, item.price),
-                            description = ('Máš %s ks'):format(count),
+                        title = ('%s ($%s / ks)'):format(_L(item.label), item.price),
+                        description = (_L('Máš %s ks')):format(count),
                             icon = 'dollar-sign',
                             onSelect = function()
-                                local input = lib.inputDialog('Prodej: ' .. item.label, {
+                                local input = lib.inputDialog(_L('Prodej: ') .. _L(item.label), {
                                     {
                                         type = 'number',
-                                        label = 'Kolik chceš prodat?',
+                                        label = _L('Kolik chceš prodat?'),
                                         default = 1,
                                         min = 1,
                                         max = count
@@ -48,13 +48,13 @@ local function createBuyer()
                 end
 
                 if #options == 0 then
-                    lib.notify({ type = 'error', description = 'Nemáš nic na prodej.' })
+                    lib.notify({ type = 'error', description = _L('Nemáš nic na prodej.') })
                     return
                 end
 
                 lib.registerContext({
                     id = 'lihovar_sell_menu',
-                    title = 'Výkup surovin',
+                    title = _L('Výkup surovin'),
                     options = options
                 })
 

--- a/lihovar_job/config.lua
+++ b/lihovar_job/config.lua
@@ -1,5 +1,40 @@
 Config = {}
 
+-- Language settings
+Config.Locale = 'en'
+Config.Lang = {
+    en = {
+        ['Sber Obilí'] = 'Gather Grain',
+        ['Vyroba lihovar'] = 'Distillery',
+        ['Koupe surovin'] = 'Buy Supplies',
+        ['Prodej produktu'] = 'Sell Products',
+        ['Prodej surovin'] = 'Sell supplies',
+        ['Sesbírat obilí'] = 'Harvest grain',
+        ['Umýváš láhve'] = 'Washing bottles',
+        ['Umít láhve'] = 'Wash bottles',
+        ['Nemáš špinavé láhve'] = 'No dirty bottles',
+        ['Nemáš houbičku na mytí, chceš umýt láhve pouze rukou?'] = 'No sponge, wash only with hands?',
+        ['Nemáš houbičku na mytí'] = 'No sponge for washing',
+        ['Nepovedlo se ti umýt flašku v ruce'] = 'Failed to wash the bottle by hand',
+        ['Kolik chceš koupit?'] = 'How many do you want to buy?',
+        ['Kolik chceš prodat?'] = 'How many do you want to sell?',
+        ['Nákup: '] = 'Purchase: ',
+        ['Prodej: '] = 'Sell: ',
+        ['Výkup surovin'] = 'Material Buyer',
+        ['lihovar obchod'] = 'Distillery Shop',
+        ['Probíhá výroba...'] = 'Processing...',
+        ['Výroba'] = 'Production',
+        ['Lihovar'] = 'Distillery',
+        ['Máš %s ks'] = 'You have %s pcs'
+    },
+    cz = {}
+}
+
+function _L(key)
+    local lang = Config.Lang[Config.Locale] or {}
+    return lang[key] or key
+end
+
 Config.RequiredJob = "lihovar"
 
 Config.HarvestCenter = vector3(349.99, 6517.27, 28.6)

--- a/pivovar_job/client/blips.lua
+++ b/pivovar_job/client/blips.lua
@@ -3,10 +3,10 @@ local blips = {}
 
 local function createBlips()
     local locations = {
-        { label = "Sber Obilí", coords = vec3(255.1872, 6457.7681, 31.4509), sprite = 496, color = 25 },
-        { label = "Vyroba pivovar", coords = vec3(2-53.1422, 6426.6831, 32.4901), sprite = 566, color = 1 },
-        { label = "Koupe surovin", coords = vec3(-58.2537, 6522.5308, 31.4908), sprite = 566, color = 1 },
-        { label = "Prodej produktu", coords = vec3(-1581.5283, 5174.4487, 19.5250), sprite = 566, color = 1 }
+        { label = _L('Sber Obilí'), coords = vec3(255.1872, 6457.7681, 31.4509), sprite = 496, color = 25 },
+        { label = _L('Vyroba pivovar'), coords = vec3(-53.1422, 6426.6831, 32.4901), sprite = 566, color = 1 },
+        { label = _L('Koupe surovin'), coords = vec3(-58.2537, 6522.5308, 31.4908), sprite = 566, color = 1 },
+        { label = _L('Prodej produktu'), coords = vec3(-1581.5283, 5174.4487, 19.5250), sprite = 566, color = 1 }
     }
 
     for _, loc in pairs(locations) do

--- a/pivovar_job/client/bottle.lua
+++ b/pivovar_job/client/bottle.lua
@@ -4,15 +4,15 @@ AddEventHandler('pivovar:washinganim', function()
     local count2 = lib.callback.await('pivovar:getItemCount2')
     if count <= 0 then
         lib.notify({
-            title = 'pivovar',
-            description = 'Nemáš špinavé láhve',
+            title = _L('pivovar'),
+            description = _L('Nemáš špinavé láhve'),
             type = 'error'
         })
         washing = false
     elseif count2 <= 0 then
         local alert = lib.alertDialog({
-            header = 'pivovar',
-            content = 'Nemáš houbičku na mytí, chceš umýt láhve pouze rukou?',
+            header = _L('pivovar'),
+            content = _L('Nemáš houbičku na mytí, chceš umýt láhve pouze rukou?'),
             centered = true,
             cancel = true
         })
@@ -25,7 +25,7 @@ AddEventHandler('pivovar:washinganim', function()
                     washing = true
                     exports.ox_inventory:Progress({
                         duration = 2500,
-                        label = "Umýváš láhve",
+                        label = _L('Umýváš láhve'),
                         useWhileDead = false,
                         canCancel = true,
                         disable = {
@@ -43,15 +43,15 @@ AddEventHandler('pivovar:washinganim', function()
                 end
             else
                 lib.notify({
-                    title = 'pivovar',
-                    description = 'Nepovedlo se ti umýt flašku v ruce',
+                    title = _L('pivovar'),
+                    description = _L('Nepovedlo se ti umýt flašku v ruce'),
                     type = 'error'
                 })
             end
         else
             lib.notify({
-                title = 'pivovar',
-                description = 'Nemáš houbičku na mytí',
+                title = _L('pivovar'),
+                description = _L('Nemáš houbičku na mytí'),
                 type = 'error'
             })
             washing = false
@@ -61,7 +61,7 @@ AddEventHandler('pivovar:washinganim', function()
             washing = true
             exports.ox_inventory:Progress({
                 duration = 2500,
-                label = "Umýváš láhve",
+                label = _L('Umýváš láhve'),
                 useWhileDead = false,
                 canCancel = true,
                 disable = {
@@ -90,7 +90,7 @@ Citizen.CreateThread(function()
         options = {
             {
                 event = "pivovar:washinganim",
-                label = "Umít láhve"
+                label = _L('Umít láhve')
             }
         },
         job = {"pivovar"},

--- a/pivovar_job/client/buy.lua
+++ b/pivovar_job/client/buy.lua
@@ -15,7 +15,7 @@ local function createShop()
         {
             name = "pivovar_shop_target",
             icon = Config.ShopNPC.icon,
-            label = Config.ShopNPC.targetLabel,
+            label = _L(Config.ShopNPC.targetLabel),
             canInteract = function(entity, distance, coords, name)
                 return ESX.GetPlayerData().job.name == Config.ShopNPC.requiredJob
             end,
@@ -23,13 +23,13 @@ local function createShop()
                 local options = {}
                 for _, item in pairs(Config.ShopNPC.items) do
                     table.insert(options, {
-                        title = (item.label or item.name) .. " ($" .. item.price .. ")",
+                        title = (_L(item.label) or item.name) .. " ($" .. item.price .. ")",
                         icon = 'cart-shopping',
                         onSelect = function()
-                            local input = lib.inputDialog('Nákup: ' .. item.label, {
+                            local input = lib.inputDialog(_L('Nákup: ') .. _L(item.label), {
                                 {
                                     type = 'number',
-                                    label = 'Kolik chceš koupit?',
+                                    label = _L('Kolik chceš koupit?'),
                                     default = 1,
                                     min = 1
                                 }
@@ -44,7 +44,7 @@ local function createShop()
 
                 lib.registerContext({
                     id = 'pivovar_shop_menu',
-                    title = 'pivovar obchod',
+                    title = _L('pivovar obchod'),
                     options = options
                 })
 

--- a/pivovar_job/client/client.lua
+++ b/pivovar_job/client/client.lua
@@ -27,7 +27,7 @@ local icons = {
 }
 
 local labels = {
-    process = "Destilace piva"
+    process = _L('Destilace Piva')
 }
 
 local craftingZoneIds = {}
@@ -54,12 +54,12 @@ local function registerCraftingTargets()
             debug = false,
             options = {{
                 icon = icons[zone.type] or "fa-solid fa-cogs",
-                label = labels[zone.type] or "Výroba",
+                label = labels[zone.type] or _L('Výroba'),
                 onSelect = function()
                     local menuId = 'pivovar_menu_' .. zone.type
                     lib.registerContext({
                         id = menuId,
-                        title = labels[zone.type] or zone.label,
+                        title = labels[zone.type] or _L(zone.label),
                         options = Config.CraftOptions[zone.type] or {}
                     })
                     lib.showContext(menuId)
@@ -83,7 +83,7 @@ RegisterNetEvent('pivovar:playCraftAnim', function(type)
 
     lib.progressBar({
         duration = duration,
-        label = 'Probíhá výroba...',
+        label = _L('Probíhá výroba...'),
         useWhileDead = false,
         canCancel = false,
         disable = {

--- a/pivovar_job/client/harvest.lua
+++ b/pivovar_job/client/harvest.lua
@@ -42,7 +42,7 @@ function SpawnPlants()
         exports.ox_target:addLocalEntity(plant, {
             {
                 icon = "fas fa-seedling",
-                label = "Sesbírat rostlinu",
+                label = _L('Sesbírat rostlinu'),
                 canInteract = function(entity, distance, coords, name)
                     return ESX.GetPlayerData().job.name == Config.RequiredJob
                 end,

--- a/pivovar_job/client/sell.lua
+++ b/pivovar_job/client/sell.lua
@@ -15,7 +15,7 @@ local function createBuyer()
         {
             name = "pivovar_buyer_target",
             icon = Config.BuyerNPC.icon,
-            label = Config.BuyerNPC.targetLabel,
+            label = _L(Config.BuyerNPC.targetLabel),
             canInteract = function(entity, distance, coords, name)
                 return ESX.GetPlayerData().job.name == Config.BuyerNPC.requiredJob
             end,
@@ -25,14 +25,14 @@ local function createBuyer()
                     local count = exports.ox_inventory:Search('count', item.name)
                     if count and count > 0 then
                         table.insert(options, {
-                            title = ('%s ($%s / ks)'):format(item.label, item.price),
-                            description = ('Máš %s ks'):format(count),
+                        title = ('%s ($%s / ks)'):format(_L(item.label), item.price),
+                        description = (_L('Máš %s ks')):format(count),
                             icon = 'dollar-sign',
                             onSelect = function()
-                                local input = lib.inputDialog('Prodej: ' .. item.label, {
+                                local input = lib.inputDialog(_L('Prodej: ') .. _L(item.label), {
                                     {
                                         type = 'number',
-                                        label = 'Kolik chceš prodat?',
+                                        label = _L('Kolik chceš prodat?'),
                                         default = 1,
                                         min = 1,
                                         max = count
@@ -48,13 +48,13 @@ local function createBuyer()
                 end
 
                 if #options == 0 then
-                    lib.notify({ type = 'error', description = 'Nemáš nic na prodej.' })
+                    lib.notify({ type = 'error', description = _L('Nemáš nic na prodej.') })
                     return
                 end
 
                 lib.registerContext({
                     id = 'pivovar_sell_menu',
-                    title = 'Výkup surovin',
+                    title = _L('Výkup surovin'),
                     options = options
                 })
 

--- a/pivovar_job/config.lua
+++ b/pivovar_job/config.lua
@@ -1,5 +1,34 @@
 Config = {}
 
+Config.Locale = 'en'
+Config.Lang = {
+    en = {
+        ['Sber Obilí'] = 'Gather Grain',
+        ['Vyroba pivovar'] = 'Brewery',
+        ['Koupe surovin'] = 'Buy Supplies',
+        ['Prodej produktu'] = 'Sell Products',
+        ['Sesbírat rostlinu'] = 'Harvest plant',
+        ['Umýváš láhve'] = 'Washing bottles',
+        ['Umít láhve'] = 'Wash bottles',
+        ['Kolik chceš koupit?'] = 'How many do you want to buy?',
+        ['Kolik chceš prodat?'] = 'How many do you want to sell?',
+        ['Nemáš nic na prodej.'] = 'Nothing to sell.',
+        ['Nákup: '] = 'Purchase: ',
+        ['Prodej: '] = 'Sell: ',
+        ['Výkup surovin'] = 'Material Buyer',
+        ['pivovar obchod'] = 'Brewery Shop',
+        ['Destilace Piva'] = 'Beer Brewing',
+        ['Výroba Piva'] = 'Brew Beer',
+        ['Probíhá výroba...'] = 'Processing...'
+    },
+    cz = {}
+}
+
+function _L(key)
+    local lang = Config.Lang[Config.Locale] or {}
+    return lang[key] or key
+end
+
 Config.RequiredJob = "pivovar"
 
 Config.HarvestCenter = vector3(255.1872, 6457.7681, 31.4509)

--- a/redwood_job/client/blips.lua
+++ b/redwood_job/client/blips.lua
@@ -3,10 +3,10 @@ local blips = {}
 
 local function createBlips()
     local locations = {
-        { label = "Sber tabaku", coords = vec3(2845.7898, 4608.7529, 47.9798), sprite = 496, color = 25 },
-        { label = "Vyroba Redwood", coords = vec3(2913.0964, 4475.8999, 48.3450), sprite = 566, color = 1 },
-        { label = "Koupe surovin", coords = vec3(-59.3794, 6523.7188, 31.4908), sprite = 566, color = 1 },
-        { label = "Prodej produktu", coords = vec3(2145.3823, 4774.7847, 41.0054), sprite = 566, color = 1 }
+        { label = _L('Sber tabaku'), coords = vec3(2845.7898, 4608.7529, 47.9798), sprite = 496, color = 25 },
+        { label = _L('Vyroba Redwood'), coords = vec3(2913.0964, 4475.8999, 48.3450), sprite = 566, color = 1 },
+        { label = _L('Koupe surovin'), coords = vec3(-59.3794, 6523.7188, 31.4908), sprite = 566, color = 1 },
+        { label = _L('Prodej produktu'), coords = vec3(2145.3823, 4774.7847, 41.0054), sprite = 566, color = 1 }
     }
 
     for _, loc in pairs(locations) do

--- a/redwood_job/client/buy.lua
+++ b/redwood_job/client/buy.lua
@@ -15,7 +15,7 @@ local function createShop()
         {
             name = "redwood_shop_target",
             icon = Config.ShopNPC.icon,
-            label = Config.ShopNPC.targetLabel,
+            label = _L(Config.ShopNPC.targetLabel),
             canInteract = function(entity, distance, coords, name)
                 return ESX.GetPlayerData().job.name == Config.ShopNPC.requiredJob
             end,
@@ -23,13 +23,13 @@ local function createShop()
                 local options = {}
                 for _, item in pairs(Config.ShopNPC.items) do
                     table.insert(options, {
-                        title = (item.label or item.name) .. " ($" .. item.price .. ")",
+                        title = (_L(item.label) or item.name) .. " ($" .. item.price .. ")",
                         icon = 'cart-shopping',
                         onSelect = function()
-                            local input = lib.inputDialog('Nákup: ' .. item.label, {
+                            local input = lib.inputDialog(_L('Nákup: ') .. _L(item.label), {
                                 {
                                     type = 'number',
-                                    label = 'Kolik chceš koupit?',
+                                    label = _L('Kolik chceš koupit?'),
                                     default = 1,
                                     min = 1
                                 }
@@ -44,7 +44,7 @@ local function createShop()
 
                 lib.registerContext({
                     id = 'redwood_shop_menu',
-                    title = 'Redwood obchod',
+                    title = _L('redwood obchod'),
                     options = options
                 })
 

--- a/redwood_job/client/client.lua
+++ b/redwood_job/client/client.lua
@@ -27,10 +27,10 @@ local icons = {
 }
 
 local labels = {
-    process = "Zpracování tabáku",
-    cigarettes = "Výroba cigaret",
-    cigars = "Výroba doutníků",
-    pack = "Balení produktů"
+    process = _L('Zpracování tabáku'),
+    cigarettes = _L('Výroba cigaret'),
+    cigars = _L('Výroba doutníků'),
+    pack = _L('Balení')
 }
 
 local craftingZoneIds = {}
@@ -57,12 +57,12 @@ local function registerCraftingTargets()
             debug = false,
             options = {{
                 icon = icons[zone.type] or "fa-solid fa-cogs",
-                label = labels[zone.type] or "Výroba",
+                label = labels[zone.type] or _L('Výroba'),
                 onSelect = function()
                     local menuId = 'redwood_menu_' .. zone.type
                     lib.registerContext({
                         id = menuId,
-                        title = labels[zone.type] or zone.label,
+                        title = labels[zone.type] or _L(zone.label),
                         options = Config.CraftOptions[zone.type] or {}
                     })
                     lib.showContext(menuId)
@@ -86,7 +86,7 @@ RegisterNetEvent('redwood:playCraftAnim', function(type)
 
     lib.progressBar({
         duration = duration,
-        label = 'Probíhá výroba...',
+        label = _L('Probíhá výroba...'),
         useWhileDead = false,
         canCancel = false,
         disable = {

--- a/redwood_job/client/harvest.lua
+++ b/redwood_job/client/harvest.lua
@@ -42,7 +42,7 @@ function SpawnPlants()
         exports.ox_target:addLocalEntity(plant, {
             {
                 icon = "fas fa-seedling",
-                label = "Sesbírat tabák",
+                label = _L('Sesbírat tabák'),
                 canInteract = function(entity, distance, coords, name)
                     return ESX.GetPlayerData().job.name == Config.RequiredJob
                 end,

--- a/redwood_job/client/sell.lua
+++ b/redwood_job/client/sell.lua
@@ -15,7 +15,7 @@ local function createBuyer()
         {
             name = "redwood_buyer_target",
             icon = Config.BuyerNPC.icon,
-            label = Config.BuyerNPC.targetLabel,
+            label = _L(Config.BuyerNPC.targetLabel),
             canInteract = function(entity, distance, coords, name)
                 return ESX.GetPlayerData().job.name == Config.BuyerNPC.requiredJob
             end,
@@ -25,14 +25,14 @@ local function createBuyer()
                     local count = exports.ox_inventory:Search('count', item.name)
                     if count and count > 0 then
                         table.insert(options, {
-                            title = ('%s ($%s / ks)'):format(item.label, item.price),
-                            description = ('Máš %s ks'):format(count),
+                        title = ('%s ($%s / ks)'):format(_L(item.label), item.price),
+                        description = (_L('Máš %s ks')):format(count),
                             icon = 'dollar-sign',
                             onSelect = function()
-                                local input = lib.inputDialog('Prodej: ' .. item.label, {
+                                local input = lib.inputDialog(_L('Prodej: ') .. _L(item.label), {
                                     {
                                         type = 'number',
-                                        label = 'Kolik chceš prodat?',
+                                        label = _L('Kolik chceš prodat?'),
                                         default = 1,
                                         min = 1,
                                         max = count
@@ -48,13 +48,13 @@ local function createBuyer()
                 end
 
                 if #options == 0 then
-                    lib.notify({ type = 'error', description = 'Nemáš nic na prodej.' })
+                    lib.notify({ type = 'error', description = _L('Nemáš nic na prodej.') })
                     return
                 end
 
                 lib.registerContext({
                     id = 'redwood_sell_menu',
-                    title = 'Výkup surovin',
+                    title = _L('Výkup surovin'),
                     options = options
                 })
 

--- a/redwood_job/config.lua
+++ b/redwood_job/config.lua
@@ -1,5 +1,34 @@
 Config = {}
 
+Config.Locale = 'en'
+Config.Lang = {
+    en = {
+        ['Sber tabaku'] = 'Collect tobacco',
+        ['Vyroba Redwood'] = 'Redwood Production',
+        ['Koupe surovin'] = 'Buy Supplies',
+        ['Prodej produktu'] = 'Sell Products',
+        ['Sesbírat tabák'] = 'Harvest tobacco',
+        ['Nákup: '] = 'Purchase: ',
+        ['Prodej: '] = 'Sell: ',
+        ['Kolik chceš koupit?'] = 'How many do you want to buy?',
+        ['Kolik chceš prodat?'] = 'How many do you want to sell?',
+        ['Nemáš nic na prodej.'] = 'Nothing to sell.',
+        ['Výkup surovin'] = 'Material Buyer',
+        ['redwood obchod'] = 'Redwood Shop',
+        ['Zpracování tabáku'] = 'Tobacco Processing',
+        ['Výroba cigaret'] = 'Make Cigarettes',
+        ['Výroba doutníků'] = 'Make Cigars',
+        ['Balení'] = 'Packing',
+        ['Probíhá výroba...'] = 'Processing...'
+    },
+    cz = {}
+}
+
+function _L(key)
+    local lang = Config.Lang[Config.Locale] or {}
+    return lang[key] or key
+end
+
 Config.RequiredJob = "redwood"
 
 Config.HarvestCenter = vector3(2845.7898, 4608.7529, 47.9798)


### PR DESCRIPTION
## Summary
- add simple language tables in config files
- show translated strings in FBI tracker
- translate UI elements for lihovar job
- translate pivovar job interactions
- translate redwood job interactions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685323052fb88330b4ecd3e036a253c7