### PR TITLE
Convert cards resource to ESX with ox_inventory

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -30,7 +30,8 @@ files {
 }
 
 dependencies {
-    'menuv'
+    'menuv',
+    'ox_inventory'
 }
 
 data_file 'DLC_ITYP_REQUEST' 'stream/booster_props.ytyp'


### PR DESCRIPTION
## Summary
- migrate the cards resource from qb-core helpers to ESX player APIs and ox_inventory exports
- update client interactions to use ox_lib progress and notification helpers while integrating ox_inventory stashes
- register ox_inventory usable items for booster packs/boxes and ensure badge trades and sales run through ESX

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfc782237c8330b188488c4346b248